### PR TITLE
Add offline US zipcode support

### DIFF
--- a/np_re_model/__init__.py
+++ b/np_re_model/__init__.py
@@ -8,6 +8,8 @@ from .geo_utils import (
     get_eps_from_miles,
     distance_to_nearest_retail,
     geocode_address,
+    get_zipcode_coordinates,
+    load_us_mainland_zipcodes,
 )
 from .data_utils import validate_columns, drop_invalid_coordinates
 __all__ = [
@@ -18,6 +20,8 @@ __all__ = [
     'get_eps_from_miles',
     'distance_to_nearest_retail',
     'geocode_address',
+    'get_zipcode_coordinates',
+    'load_us_mainland_zipcodes',
     'validate_columns',
     'drop_invalid_coordinates',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ geopy>=2.2,<3.0
 Flask>=3.1,<4.0
 # Optional: only required if using the HDBSCAN algorithm
 hdbscan>=0.8,<0.9
+# Offline US zip code lookup
+zipcodes>=1.3,<2.0

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,5 +1,8 @@
 import unittest
+import os
+import sys
 import pandas as pd
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from np_re_model.clustering import weighted_kmeans_clustering, dbscan_clustering
 
 class TestClustering(unittest.TestCase):

--- a/tests/test_zipcodes.py
+++ b/tests/test_zipcodes.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from np_re_model import get_zipcode_coordinates, load_us_mainland_zipcodes
+
+class TestZipcodeUtils(unittest.TestCase):
+    def test_get_zipcode_coordinates(self):
+        lat, lon = get_zipcode_coordinates('10001')
+        self.assertIsNotNone(lat)
+        self.assertIsNotNone(lon)
+
+    def test_load_us_mainland_zipcodes(self):
+        df = load_us_mainland_zipcodes()
+        self.assertGreater(len(df), 30000)
+        self.assertIn('zip_code', df.columns)
+        self.assertIn('latitude', df.columns)
+        self.assertIn('longitude', df.columns)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable offline US zipcode lookup using the `zipcodes` library
- export new helper functions in `np_re_model`
- include `zipcodes` as a requirement
- update tests to import the package path
- add new tests for zipcode utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846255733508330828c7da7263a7584